### PR TITLE
Fixed bug in SQL query

### DIFF
--- a/src/main/java/com/example/app10/MainActivity.kt
+++ b/src/main/java/com/example/app10/MainActivity.kt
@@ -36,7 +36,7 @@ object FeedReaderContract {
 // SQL statement to create the database table
 private const val SQL_CREATE_ENTRIES =
     "CREATE TABLE ${FeedReaderContract.FeedEntry.TABLE_NAME} (" +
-            "${BaseColumns._ID} PRIMARY KEY," +
+            "${BaseColumns._ID} INTEGER PRIMARY KEY," +
             "${FeedReaderContract.FeedEntry.NAME} TEXT," +
             "${FeedReaderContract.FeedEntry.PHONE_NUMBER} TEXT)"
 


### PR DESCRIPTION
Descriere Bug:
Am identificat un bug in codul SQL de creare a tabelului in baza de date. Coloana pentru cheia primara nu avea specificat tipul de date. Astfel, am observat ca PRIMARY KEY nu avea specificat tipul INTEGER, ceea ce ducea la probleme de functionare.

Solutie:
Am actualizat SQL-ul  pentru a include tipul INTEGER pentru coloana cheii primare. Acum, cheia primara este definita corect ca INTEGER PRIMARY KEY.

Cod actualizat:
private const val SQL_CREATE_ENTRIES =
    "CREATE TABLE ${FeedReaderContract.FeedEntry.TABLE_NAME} (" +
            "${BaseColumns._ID} INTEGER PRIMARY KEY," +
            "${FeedReaderContract.FeedEntry.NAME} TEXT," +
            "${FeedReaderContract.FeedEntry.PHONE_NUMBER} TEXT)"